### PR TITLE
inclui as anotações preAuthorize para proteger endpont de chamados

### DIFF
--- a/src/main/java/org/soulcodeacademy/helpr/controllers/ChamadoController.java
+++ b/src/main/java/org/soulcodeacademy/helpr/controllers/ChamadoController.java
@@ -6,6 +6,7 @@ import org.soulcodeacademy.helpr.domain.enums.StatusChamado;
 import org.soulcodeacademy.helpr.services.ChamadoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -17,21 +18,26 @@ public class ChamadoController {
     @Autowired
     private ChamadoService chamadoService;
 
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_FUNCIONARIO')")
     @GetMapping("/chamados")
     public List<Chamado> listarChamados() {
         return this.chamadoService.listarChamados();
     }
 
+
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_FUNCIONARIO')")
     @GetMapping("/chamados/{idChamado}")
     public Chamado getChamado(@PathVariable Integer idChamado) {
         return this.chamadoService.getChamado(idChamado);
     }
 
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_FUNCIONARIO','ROLE_CLIENTE')")
     @PostMapping("/chamados")
     public Chamado salvar(@Valid @RequestBody ChamadoDTO dto) {
         return this.chamadoService.salvar(dto);
     }
 
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_FUNCIONARIO')")
     @PutMapping("/chamados/{idChamado}")
     public Chamado atualizar(@PathVariable Integer idChamado, @Valid @RequestBody ChamadoDTO dto) {
         return this.chamadoService.atualizar(idChamado, dto);


### PR DESCRIPTION
fiz o uso da anotação @PreAuthorize para proteger os endpoints do ChamadoController:

Listar chamados: ADMIN, FUNCIONARIO;
Salvar chamados: ADMIN, FUNCIONARIO, CLIENTE;
Atualizar chamados: ADMIN, FUNCIONARIO